### PR TITLE
Close #18, cache files for S3

### DIFF
--- a/docassemble/ALKilnInThePlayground/data/questions/run_alkiln_tests.yml
+++ b/docassemble/ALKilnInThePlayground/data/questions/run_alkiln_tests.yml
@@ -451,6 +451,15 @@ code: |
   
   # if statement for idempotency - ensure tests are only run once
   if not has_run_tests:
+  
+    # Ensure that files in the 'sources' folder of all projects are
+    # cached in /tmp for S3 and such server configurations so that
+    # alkiln can get them there. They should be there for 2hrs at least.
+    # It's not possible to just pick one project.
+    # From https://github.com/SuffolkLITLab/docassemble-ALDashboard/blob/main/docassemble/ALDashboard/create_package.py#L14-L17
+    SavedFile(user_info().id, fix=True, section='playgroundsources')
+  
+    # Run the tests
     other_env_vars = action_argument('env_vars')
     test_output = subprocess.run(
       ['/var/www/.npm-global/bin/alkiln-run'],


### PR DESCRIPTION
Confirmed as working on an S3 server. Steps I did:
1. Pull a package with files in the `sources` folder
2. Checked in the console that the files were there
3. Deleted a file
4. Ran ALKiln in the Playground on the project with a test that needed that file
5. Checked in the console that the files were back
Result: The files were back and tests passed

Closes #18. Closes https://github.com/SuffolkLITLab/ALKiln/issues/719